### PR TITLE
Change base image to centos 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/httpd-24-centos7
+FROM centos:8
 
 ARG VERSION=v3.2.0
 ARG REPO=SpiderLabs/owasp-modsecurity-crs
@@ -51,6 +51,10 @@ ENV PARANOIA=1 \
     PROXY_TIMEOUT=30
 
 USER root
+RUN yum install -y httpd mod_security mod_ssl curl && \
+    yum -y update && \
+    yum clean all
+
 RUN mkdir -p /var/log/modsecurity/audit \
     /etc/httpd/modsecurity/puzzle/custom-before-crs /etc/httpd/modsecurity/service/custom-before-crs \
     /etc/httpd/modsecurity/puzzle/custom-after-crs /etc/httpd/modsecurity/service/custom-after-crs

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Important for us (Puzzle) are:
 
 ## Test the container locally
 
-`docker run -dti -e PARANOIA=2 -e EXECUTING_PARANOIA=2 -e BACKEND='https://myserver:8443 -e SERVERNAME='myserver.puzzle.ch' quay.io/puzzleitc/centos-apache-modsecurity:crs-v3.2.0-waf1`
+`docker run -dti -e PARANOIA=2 -e EXECUTING_PARANOIA=2 -e BACKEND='https://myserver:8443' -e SERVERNAME='myserver.puzzle.ch' quay.io/puzzleitc/centos-apache-modsecurity:crs-v3.2.0-waf1`
 
 For convenience, a [docker-compose](./docker-compose.yaml) file with preconfigured volumes and environment variables is available.
 


### PR DESCRIPTION
The old base image centos/httpd-24-centos7 has an intermediate image that has not been maintained.
To fix this security problem and to reduce the image size, we are changing the base image to Centos, in the latest version 8.

After the merge of this PR, we will release a new version of the WAF: crs-v3.2.0-waf2. 