### PR TITLE
Deactivate quay push and add tags to checkout

### DIFF
--- a/.github/workflows/quay-push.yml
+++ b/.github/workflows/quay-push.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1
+        ref: ${{ matrix.tag }}
 
     - name: Build Image
       id: build-image
@@ -28,15 +29,15 @@ jobs:
 
     # Podman Login action (https://github.com/redhat-actions/podman-login) also be used to log in,
     # in which case 'username' and 'password' can be omitted.
-    - name: Push To quay.io
-      id: push-to-quay
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{ steps.build-image.outputs.image }}
-        tags: ${{ steps.build-image.outputs.tags }}
-        registry: quay.io/
-        username: ${{ secrets.QUAY_USER }}
-        password: ${{ secrets.QUAY_PASSWORD }}
+    #    - name: Push To quay.io
+    #      id: push-to-quay
+    #      uses: redhat-actions/push-to-registry@v2
+    #      with:
+    #        image: ${{ steps.build-image.outputs.image }}
+    #        tags: ${{ steps.build-image.outputs.tags }}
+    #        registry: quay.io/
+    #        username: ${{ secrets.QUAY_USER }}
+    #        password: ${{ secrets.QUAY_PASSWORD }}
 
-    - name: Print image url
-      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+          #    - name: Print image url
+          #      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
Dieser MR deaktiviert den Push auf Quay und fügt das Checkout des Tags anstatt "main" hinzu.

Ziel: nächsten Montag wird der Release Tag nicht überschrieben.